### PR TITLE
Remove the extra top level /etc/ in root.tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ $(tag):
 	mkdir $@
 
 $(tag)/root.tar: roots/$(tag)/etc $(tag)
-	cd roots/$(tag) \
-		&& tar -c --numeric-owner -f ../../$(tag)/root.tar ./
+	cd roots/$(tag)/etc \
+		&& tar -c --numeric-owner -f ../../../$(tag)/root.tar ./
 
 # slightly awkward indirection to avoid a bug whereby user runs
 # this unprivileged, creates the dir but debootstrap fails, but


### PR DESCRIPTION
d63573d added a layer of indirection, depending on the "etc" subdirectory.
The cd command should now go into the etc subdirectory before tar is invoked.
Similarly, the file path of "tar cf" should go up one more level to get out
of etc for root.tar to be created in the right location.

This fixes issue #11.
