### PR TITLE
refer to the root directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ roots/$(tag):
 	mkdir -p $@
 
 roots/$(tag)/etc: roots/$(tag)
-	debootstrap --arch $(arch) $(release) $@ $(mirror) \
-		&& chroot $@ apt-get clean
+	debootstrap --arch $(arch) $(release) $< $(mirror) \
+		&& chroot $< apt-get clean
 
 clean:
 	rm -f $(tag)/root.tar $(tag)/Dockerfile


### PR DESCRIPTION
Using "etc" as an indication of a complete tree may work but the commands that generate the "etc" directory and run apt-get in chroot rely on the top-level directory.  Fixes #11.
