### PR TITLE
Proxy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ $(tag)/root.tar: roots/$(tag).ok $(tag)
 roots/$(tag).ok:
 	debootstrap --arch $(arch) $(release) roots/$(tag) $(mirror) \
 		&& chroot roots/$(tag) apt-get clean
+	if [ "$(http_proxy)" ]; then \
+		echo 'Acquire::HTTP::Proxy "$(http_proxy)";' > roots/$(tag)/etc/apt/apt.conf.d/01proxy; \
+	fi
 	touch $@
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -21,23 +21,17 @@ $(tag)/Dockerfile: Dockerfile.in $(tag)
 $(tag):
 	mkdir $@
 
-$(tag)/root.tar: roots/$(tag)/etc $(tag)
+$(tag)/root.tar: roots/$(tag).ok $(tag)
 	cd roots/$(tag) \
 		&& tar -c --numeric-owner -f ../../$(tag)/root.tar ./
 
-# slightly awkward indirection to avoid a bug whereby user runs
-# this unprivileged, creates the dir but debootstrap fails, but
-# the target is satisfied and a subsequent run believes the rule
-# satisfied
-roots/$(tag):
-	mkdir -p $@
-
-roots/$(tag)/etc: roots/$(tag)
-	debootstrap --arch $(arch) $(release) $< $(mirror) \
-		&& chroot $< apt-get clean
+roots/$(tag).ok:
+	debootstrap --arch $(arch) $(release) roots/$(tag) $(mirror) \
+		&& chroot roots/$(tag) apt-get clean
+	touch $@
 
 clean:
-	rm -f $(tag)/root.tar $(tag)/Dockerfile
+	rm -f $(tag)/root.tar $(tag)/Dockerfile roots/$(tag).ok
 	rm -r roots/$(tag)
 	test -d $(tag) && rmdir $(tag)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ sudo make release=jessie prefix=jmtd arch=amd64 mirror=http://httpredir.debian.o
 All the arguments above are optional. The values in the example above are
 the defaults. The resulting image would be tagged `jmtd/debian:jessie-amd64`.
 
+## Proxy support
+
+You can run make with a http_proxy option to use something like apt-cacher-ng:
+
+```
+sudo make http_proxy="http://10.10.5.1:3142"
+```
+
+If you do this, debootstrap will use this proxy to download packages.
+Additionally a /etc/apt/apt.conf.d/01proxy file will be added to the finished
+image, so that all future apt runs inside Docker will also use that proxy.
+
 ## Future work
 
 I don't want to maintain a zillion different images, but there are a few other


### PR DESCRIPTION
This allows to configure a central apt proxy (I use apt-cacher-ng) for all your Docker instances spawned from this template.

PS: I'm not quite sure where to add new extensions to this build, the makefile or the dockerfile. I'm inclined to move more stuff from the dockerfile to the makefile to reduce the docker layers...
